### PR TITLE
Updating to latest rascal and rascal-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.rascalmpl</groupId>
                 <artifactId>rascal-maven-plugin</artifactId>
-                <version>0.28.8</version>
+                <version>0.28.9</version>
                 <configuration>
                     <bin>${project.build.outputDirectory}</bin>
                     <srcs>
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>org.rascalmpl</groupId>
             <artifactId>rascal</artifactId>
-            <version>0.40.14</version>
+            <version>0.40.17</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Updated to
* `rascal`: 0.40.17
* `rascal-maven-plugin`: 0.28.9