### PR TITLE
Fixed Rascal packager configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
                     </execution>
                     <execution>
                         <id>package</id>
-                        <phase>pre-package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>package</goal>
                         </goals>


### PR DESCRIPTION
This PR ensures that, during a build, CI locations in `tpl` files are correctly rewritten to `mvn:///` locations